### PR TITLE
Add base_model_prefix

### DIFF
--- a/enformer_pytorch/modeling_enformer.py
+++ b/enformer_pytorch/modeling_enformer.py
@@ -293,6 +293,7 @@ class Attention(nn.Module):
 
 class Enformer(PreTrainedModel):
     config_class = EnformerConfig
+    base_model_prefix = "enformer"
 
     @staticmethod
     def from_hparams(**kwargs):


### PR DESCRIPTION
This PR fixes the `from_pretrained` method by adding `base_model_prefix`, as this makes sure weights are properly loaded from the hub.

Kudos to @sgugger for finding the bug.