### PR TITLE
Remove depreciated torchmetrics __init__ argument and fix str_to_one_hot for CUDA devices

### DIFF
--- a/enformer_pytorch/metrics.py
+++ b/enformer_pytorch/metrics.py
@@ -5,11 +5,10 @@ import torch
 
 class MeanPearsonCorrCoefPerChannel(Metric):
     is_differentiable: Optional[bool] = False
-    full_state_update:bool = False
     higher_is_better: Optional[bool] = True
     def __init__(self, n_channels:int, dist_sync_on_step=False):
         """Calculates the mean pearson correlation across channels aggregated over regions"""
-        super().__init__(dist_sync_on_step=dist_sync_on_step, full_state_update=False)
+        super().__init__(dist_sync_on_step=dist_sync_on_step)
         self.reduce_dims=(0, 1)
         self.add_state("product", default=torch.zeros(n_channels, dtype=torch.float32), dist_reduce_fx="sum", )
         self.add_state("true", default=torch.zeros(n_channels, dtype=torch.float32), dist_reduce_fx="sum", )

--- a/enformer_pytorch/modeling_enformer.py
+++ b/enformer_pytorch/modeling_enformer.py
@@ -408,8 +408,9 @@ class Enformer(PreTrainedModel):
         if isinstance(x, list):
             x = str_to_one_hot(x)
 
-        elif x.dtype == torch.long:
+        elif type(x) == torch.Tensor and x.dtype == torch.long:
             x = seq_indices_to_one_hot(x)
+        x.to(self.device)
 
         no_batch = x.ndim == 2
 


### PR DESCRIPTION
MeanPearsonCorrCoefPerChannel currently cannot be instantiated due to it's use of the depreciated full_state_update argument.

str_to_one_hot does not attempt to ensure that the produced tensor is on the same device as Enformer. If torch, by default maps tensors to CPU, passing a string will cause an error in Enformer.forward(). 