### PR TITLE
updated the assert to check if the seq_length == 196_608 when use_tf_…

### DIFF
--- a/enformer_pytorch/modeling_enformer.py
+++ b/enformer_pytorch/modeling_enformer.py
@@ -110,7 +110,7 @@ def get_positional_features_gamma(positions, features, seq_len, stddev = None, s
 def get_positional_embed(seq_len, feature_size, device, use_tf_gamma, dtype = torch.float):
     distances = torch.arange(-seq_len + 1, seq_len, device = device)
 
-    assert not use_tf_gamma or seq_len == 1536, 'if using tf gamma, only sequence length of 1536 allowed for now'
+    assert not use_tf_gamma or seq_len == 196_608, 'if using tf gamma, only sequence length of  196_608 allowed for now'
 
     feature_functions = [
         get_positional_features_exponential,


### PR DESCRIPTION
…gamma=True

Update modeling_enformer.py to regular behavior of seq_length==196608.

I can verify that post this both TF-sonnet and the pytorch predictions are almost exact.