### PR TITLE
Fix the incorrect instruction for running the pre-trained Enformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ import torch
 from enformer_pytorch import from_pretrained
 from enformer_pytorch.finetune import HeadAdapterWrapper
 
-enformer = from_pretrained('EleutherAI/enformer-official-rough')
+enformer = from_pretrained('EleutherAI/enformer-official-rough', use_tf_gamma = False) #false is required for running with sequence longer than 1536
 
 model = HeadAdapterWrapper(
     enformer = enformer,
@@ -197,7 +197,7 @@ import torch
 from enformer_pytorch import from_pretrained
 from enformer_pytorch.finetune import ContextAdapterWrapper
 
-enformer = from_pretrained('EleutherAI/enformer-official-rough')
+enformer = from_pretrained('EleutherAI/enformer-official-rough', use_tf_gamma = False)
     
 model = ContextAdapterWrapper(
     enformer = enformer,
@@ -225,7 +225,7 @@ import torch
 from enformer_pytorch import from_pretrained
 from enformer_pytorch.finetune import ContextAttentionAdapterWrapper
 
-enformer = from_pretrained('EleutherAI/enformer-official-rough')
+enformer = from_pretrained('EleutherAI/enformer-official-rough', use_tf_gamma = False)
     
 model = ContextAttentionAdapterWrapper(
     enformer = enformer,


### PR DESCRIPTION
Hi, I notice that there exist a bug for running emformer with tf_gamma setting for sequence longer than 1536, which is not reflected in the readme page. Therefore, I add such requirements to enhance the usability.

The related bug is: https://github.com/lucidrains/enformer-pytorch/issues/40

Thanks.