### PR TITLE
fromstring in one-hot encoding issue

### DIFF
--- a/enformer_pytorch/data.py
+++ b/enformer_pytorch/data.py
@@ -55,7 +55,7 @@ reverse_complement_map = torch.Tensor([3, 2, 1, 0, 4]).long()
 def torch_fromstring(seq_strs):
     batched = not isinstance(seq_strs, str)
     seq_strs = cast_list(seq_strs)
-    np_seq_chrs = list(map(lambda t: np.fromstring(t, dtype = np.uint8), seq_strs))
+    np_seq_chrs = list(map(lambda t: np.frombuffer(t.encode(), dtype = np.uint8).copy(), seq_strs))
     seq_chrs = list(map(torch.from_numpy, np_seq_chrs))
     return torch.stack(seq_chrs) if batched else seq_chrs[0]
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
   install_requires=[
     'discrete-key-value-bottleneck-pytorch>=0.0.8',
     'einops>=0.3',
-    'numpy',
+    'numpy>=2.3.1',
     'torch>=1.6',
     'torchmetrics',
     'polars',


### PR DESCRIPTION
## Issue Description
The library fails when processing DNA sequences due to a breaking change in NumPy where `np.fromstring()` in binary mode has been removed.

## Error Details
```
ValueError: The binary mode of fromstring is removed, use frombuffer instead
```

**Stack Trace:**
```
File "/home/jeff/iv3/repos/tf-bind-transformer/tf_bind_transformer/data_bigwig2.py", line 100, in __getitem__
  seq = self.fasta(chr_name, begin, end)
File "/home/jeff/iv3/repos/enformer-pytorch/enformer_pytorch/data.py", line 157, in __call__
  one_hot = str_to_one_hot(seq)
File "/home/jeff/iv3/repos/enformer-pytorch/enformer_pytorch/data.py", line 67, in str_to_one_hot
  seq_chrs = torch_fromstring(seq_strs)
File "/home/jeff/iv3/repos/enformer-pytorch/enformer_pytorch/data.py", line 58, in torch_fromstring
  np_seq_chrs = list(map(lambda t: np.fromstring(t, dtype = np.uint8), seq_strs))
File "/home/jeff/iv3/repos/enformer-pytorch/enformer_pytorch/data.py", line 58, in <lambda>
  np_seq_chrs = list(map(lambda t: np.fromstring(t, dtype = np.uint8), seq_strs))
```
